### PR TITLE
タスク一覧ページとタスク作成ページの修正

### DIFF
--- a/app/(overview)/page.tsx
+++ b/app/(overview)/page.tsx
@@ -2,24 +2,26 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import TaskList from '../../components/TaskList';
 import useTaskStorage from '../../hooks/useTaskStorage';
 
 export default function Page() {
-  const { tasks, addDummyTask } = useTaskStorage({
+  const { tasks } = useTaskStorage({
     key: 'task-list',
   });
+  const router = useRouter();
 
   return (
     <main className="max-w-2xl mx-auto py-10 px-4">
       <h1 className="text-2xl font-bold mb-6">タスク一覧ページ</h1>
       <button
-        onClick={addDummyTask}
+        onClick={() => router.push('/new')}
         className="mb-6 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
       >
-        ダミータスクを追加
+        作成
       </button>
       <TaskList tasks={tasks} />
     </main>
   );
-};
+}

--- a/app/(overview)/page.tsx
+++ b/app/(overview)/page.tsx
@@ -4,12 +4,8 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import TaskList from '../../components/TaskList';
-import useTaskStorage from '../../hooks/useTaskStorage';
 
 export default function Page() {
-  const { tasks } = useTaskStorage({
-    key: 'task-list',
-  });
   const router = useRouter();
 
   return (
@@ -21,7 +17,7 @@ export default function Page() {
       >
         作成
       </button>
-      <TaskList tasks={tasks} />
+      <TaskList />
     </main>
   );
 }

--- a/app/[id]/edit/page.tsx
+++ b/app/[id]/edit/page.tsx
@@ -1,7 +1,85 @@
-import React from 'react';
+// app/[id]/edit/page.tsx
+'use client';
 
-export default function Page() {
+import React, { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import useTaskStorage from '../../../hooks/useTaskStorage';
+import { Task } from '../../../types/task';
+
+export default function EditTaskPage() {
+  const router = useRouter();
+  const params = useParams();
+  const { tasks, updateTask } = useTaskStorage({ key: 'task-list' });
+
+  const [task, setTask] = useState<Task | null>(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    const target = tasks.find(t => t.id === params.id);
+    if (target) {
+      setTask(target);
+      setTitle(target.title);
+      setDescription(target.description);
+    }
+  }, [params.id, tasks]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!task) return;
+
+    updateTask({
+      ...task,
+      title,
+      description,
+    });
+
+    router.push('/');
+  };
+
+  if (!task) {
+    return <div className="p-4 text-center">タスクが見つかりません</div>;
+  }
+
   return (
-    <div>タスク編集ページ</div>
+    <main className="max-w-xl mx-auto py-10 px-4">
+      <h1 className="text-2xl font-bold mb-6">タスクを編集</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-semibold mb-1">タイトル</label>
+          <input
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">説明</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+            rows={4}
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => router.push('/')}
+            className="px-4 py-2 rounded border"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            保存
+          </button>
+        </div>
+      </form>
+    </main>
   );
 }

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,7 +1,71 @@
-import React from 'react';
+// app/new/page.tsx
+'use client';
 
-export default function Page() {
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import useTaskStorage from '../../hooks/useTaskStorage';
+
+export default function NewTaskPage() {
+  const router = useRouter();
+  const { addTask } = useTaskStorage({ key: 'task-list' });
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim()) return;
+
+    addTask({
+      id: Date.now().toString(),
+      title,
+      description,
+      completed: false, 
+    });
+
+    router.push('/');
+  };
+
   return (
-    <div>タスク作成ページ</div>
+    <main className="max-w-xl mx-auto py-10 px-4">
+      <h1 className="text-2xl font-bold mb-6">新規タスク作成</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-semibold mb-1">タイトル</label>
+          <input
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold mb-1">説明</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            className="w-full border rounded px-3 py-2"
+            rows={4}
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => router.push('/')}
+            className="px-4 py-2 rounded border"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+          >
+            作成
+          </button>
+        </div>
+      </form>
+    </main>
   );
 }

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -37,7 +37,11 @@ const TaskItem = ({ task, onToggle, onDelete }: Props) => {
         </button>
         <button
           className="text-red-500 text-sm hover:underline"
-          onClick={() => onDelete?.(task.id)}
+          onClick={() => {
+            if (window.confirm('このタスクを削除してもよろしいですか？')) {
+              onDelete?.(task.id);
+            }
+          }}
         >
           削除
         </button>

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -1,5 +1,8 @@
 // components/TaskItem.tsx
+'use client';
+
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import { Task } from '../types/task';
 
 type Props = {
@@ -9,6 +12,8 @@ type Props = {
 };
 
 const TaskItem = ({ task, onToggle, onDelete }: Props) => {
+  const router = useRouter();
+
   return (
     <div className="p-4 border rounded shadow-sm bg-white flex items-start justify-between">
       <div className="flex items-start gap-2">
@@ -23,17 +28,22 @@ const TaskItem = ({ task, onToggle, onDelete }: Props) => {
           <p className="text-sm text-gray-600">{task.description || '（詳細なし）'}</p>
         </div>
       </div>
-      {onDelete && (
+      <div className="flex flex-row items-center gap-2">
+        <button
+          className="text-blue-500 text-sm hover:underline"
+          onClick={() => router.push(`/${task.id}/edit`)}
+        >
+          編集
+        </button>
         <button
           className="text-red-500 text-sm hover:underline"
-          onClick={() => onDelete(task.id)}
+          onClick={() => onDelete?.(task.id)}
         >
           削除
         </button>
-      )}
+      </div>
     </div>
   );
 };
-
 
 export default TaskItem;

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -1,9 +1,13 @@
 // components/TaskList.tsx
-import React from 'react';
-import { Task } from '../types/task';
-import TaskItem from './TaskItem';
+'use client';
 
-const TaskList = ({ tasks }: { tasks: Task[] }) => {
+import React from 'react';
+import TaskItem from './TaskItem';
+import useTaskStorage from '../hooks/useTaskStorage';
+
+const TaskList = () => {
+  const { tasks, toggleTask, deleteTask } = useTaskStorage({ key: 'task-list' });
+
   const sorted = [...tasks].sort((a, b) => Number(a.completed) - Number(b.completed));
 
   return (
@@ -11,7 +15,14 @@ const TaskList = ({ tasks }: { tasks: Task[] }) => {
       {sorted.length === 0 ? (
         <p className="text-gray-500">タスクがありません</p>
       ) : (
-        sorted.map(task => <TaskItem key={task.id} task={task} />)
+        sorted.map(task => (
+          <TaskItem
+            key={task.id}
+            task={task}
+            onToggle={toggleTask}
+            onDelete={deleteTask}
+          />
+        ))
       )}
     </div>
   );

--- a/hooks/useTaskStorage.ts
+++ b/hooks/useTaskStorage.ts
@@ -20,18 +20,11 @@ export default function useTaskStorage(props: useTaskStorageProps) {
     }
   }, [props.key]);
 
-  const addDummyTask = () => {
-    const newTask: Task = {
-      id: generateId(),
-      title: 'ダミータスク ' + (localState.length + 1),
-      description: 'これはテスト用のダミータスクです。',
-      completed: false,
-    };
-
-    const updated = [...localState, newTask];
+  const addTask = (task: Task) => {
+    const updated = [...localState, task];
     localStorage.setItem(props.key, JSON.stringify(updated));
     setLocalState(updated);
   };
 
-  return { tasks: localState, addDummyTask: addDummyTask };
+  return { tasks: localState, addTask: addTask };
 }

--- a/hooks/useTaskStorage.ts
+++ b/hooks/useTaskStorage.ts
@@ -26,5 +26,17 @@ export default function useTaskStorage(props: useTaskStorageProps) {
     setLocalState(updated);
   };
 
-  return { tasks: localState, addTask: addTask };
+  const updateTask = (updatedTask: Task) => {
+    const updated = localState.map(task =>
+      task.id === updatedTask.id ? updatedTask : task
+    );
+    localStorage.setItem(props.key, JSON.stringify(updated));
+    setLocalState(updated);
+  };
+
+  return {
+    tasks: localState,
+    addTask,
+    updateTask,
+  };
 }

--- a/hooks/useTaskStorage.ts
+++ b/hooks/useTaskStorage.ts
@@ -34,9 +34,25 @@ export default function useTaskStorage(props: useTaskStorageProps) {
     setLocalState(updated);
   };
 
+  const toggleTask = (id: string) => {
+    const updated = localState.map((task) =>
+      task.id === id ? { ...task, completed: !task.completed } : task
+    );
+    setLocalState(updated);
+    localStorage.setItem(props.key, JSON.stringify(updated));
+  };
+
+  const deleteTask = (id: string) => {
+    const updated = localState.filter((task) => task.id !== id);
+    setLocalState(updated);
+    localStorage.setItem(props.key, JSON.stringify(updated));
+  };
+
   return {
     tasks: localState,
     addTask,
     updateTask,
+    toggleTask,
+    deleteTask,
   };
 }


### PR DESCRIPTION
【タスク一覧画面】
・ダミータスク作成ボタンを削除
・タスク一覧画面への遷移ボタンを追加

【タスク作成画面】
・タイトルの入力（必須項目）
・詳細の入力（任意項目）
・更新ボタンの実装（必須項目のエラーチェック）、更新後一覧ページに遷移
・キャンセルボタンの実装、一覧ページに遷移